### PR TITLE
Set ART optimisation to "everything"

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -62,6 +62,11 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.build.selinux=1
+    
+# Ensures ART compiles almost everything on boot
+PRODUCT_PROPERTY_OVERRIDES += \
+    dalvik.vm.image-dex2oat-filter=everything \
+    dalvik.vm.dex2oat-filter=everything
 
 # Thank you, please drive thru!
 PRODUCT_PROPERTY_OVERRIDES += persist.sys.dun.override=0


### PR DESCRIPTION
Props to https://github.com/Chroma-Aosp/android_vendor_chroma/commit/a8ecd5b2e4724448ccf92b29e08eb1a249e21957

This change ensures the ART compiles almost everything on boot, to speed up later execution. This slows down the first boot after wipe but should make the experience a lot smoother.

Please note that a cache wipe is required after flashing this, to ensure everything is compiled.